### PR TITLE
Add batched distance computation support to Mahalanobis distance

### DIFF
--- a/inFairness/distances/mahalanobis_distance.py
+++ b/inFairness/distances/mahalanobis_distance.py
@@ -1,4 +1,6 @@
 import torch
+import numpy as np
+from functorch import vmap
 
 from inFairness.distances.distance import Distance
 
@@ -43,25 +45,89 @@ class MahalanobisDistances(Distance):
 
         self.sigma = sigma
 
-    def forward(self, X1, X2):
+    @staticmethod
+    def __compute_dist__(X1, X2, sigma):
+        """Computes the distance between two data samples x1 and x2
+
+        Parameters
+        -----------
+            X1: torch.Tensor
+                Data sample of shape (n_features) or (N, n_features)
+            X2: torch.Tensor
+                Data sample of shape (n_features) or (N, n_features)
+
+        Returns:
+            dist: torch.Tensor
+                Distance between points x1 and x2. Shape: (N)
+        """
+
+        # unsqueeze batch dimension if a vector is passed
+        if len(X1.shape) == 1:
+            X1 = X1.unsqueeze(0)
+        if len(X2.shape) == 1:
+            X2 = X2.unsqueeze(0)
+
+        X_diff = X1 - X2
+        dist = torch.sum((X_diff @ sigma) * X_diff, dim=-1, keepdim=True)
+        return dist
+
+    def forward(self, X1, X2, itemwise_dist=True):
         """Computes the distance between data samples X1 and X2
 
         Parameters
         -----------
             X1: torch.Tensor
-                Data samples from batch 1 of shape (n_samples, n_features)
+                Data samples from batch 1 of shape (n_samples_1, n_features)
             X2: torch.Tensor
-                Data samples from batch 2 of shape (n_samples, n_features)
+                Data samples from batch 2 of shape (n_samples_2, n_features)
+            itemwise_dist: bool, default: True
+                Compute the distance in an itemwise manner or pairwise manner.
+
+                In the itemwise fashion (`itemwise_dist=False`), distance is
+                computed between the ith data sample in X1 to the ith data sample
+                in X2. Thus, the two data samples X1 and X2 should be of the same shape
+
+                In the pairwise fashion (`itemwise_dist=False`), distance is
+                computed between all the samples in X1 and all the samples in X2.
+                In this case, the two data samples X1 and X2 can be of different shapes.
 
         Returns
         ----------
             dist: torch.Tensor
-                Distance between each sample of batch 1 and batch 2.
-                Resulting shape is (n_samples, 1)
+                Distance between samples of batch 1 and batch 2.
+
+                If `itemwise_dist=True`, item-wise distance is returned of
+                shape (n_samples, 1)
+
+                If `itemwise_dist=False`, pair-wise distance is returned of
+                shape (n_samples_1, n_samples_2)
         """
 
-        X_diff = X1 - X2
-        dist = torch.sum((X_diff @ self.sigma) * X_diff, dim=-1, keepdim=True)
+        if itemwise_dist:
+            np.testing.assert_array_equal(
+                X1.shape,
+                X2.shape,
+                err_msg="X1 and X2 should be of the same shape for itemwise distance computation",
+            )
+            dist = self.__compute_dist__(X1, X2, self.sigma)
+        else:
+            X1 = X1.unsqueeze(0) if len(X1.shape) == 2 else X1  # (B, N, D)
+            X2 = X2.unsqueeze(0) if len(X2.shape) == 2 else X2  # (B, M, D)
+
+            nsamples_x1 = X1.shape[1]
+            nsamples_x2 = X2.shape[1]
+            dist_shape = (-1, nsamples_x1, nsamples_x2)
+
+            vdist = vmap(
+                vmap(
+                    vmap(self.__compute_dist__, in_dims=(None, 0, None)),
+                    in_dims=(0, None, None),
+                ),
+                in_dims=(0, 0, None),
+            )
+
+            dist = vdist(X1, X2, self.sigma).view(dist_shape)
+
         return dist
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ numpy>=1.21.6
 scikit-learn>=0.24.2
 pandas>=1.3.5
 scipy>=1.5.4
+functorch>=0.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ numpy>=1.21.6
 scikit-learn>=0.24.2
 pandas>=1.3.5
 scipy>=1.5.4
-functorch>=0.2.0
+functorch~=0.1.1

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ setup(
         "scikit-learn>=0.24.2",
         "pandas>=1.3.5",
         "scipy>=1.5.4",
+        "functorch>=0.2.0"
     ],
     description="inFairness is a Python package to train and audit individually fair PyTorch models",
     long_description=long_description,

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
         "scikit-learn>=0.24.2",
         "pandas>=1.3.5",
         "scipy>=1.5.4",
-        "functorch>=0.2.0"
+        "functorch~=0.1.1"
     ],
     description="inFairness is a Python package to train and audit individually fair PyTorch models",
     long_description=long_description,

--- a/tests/distances/test_common_distances.py
+++ b/tests/distances/test_common_distances.py
@@ -57,7 +57,11 @@ def test_protected_euclidean_distance():
     assert torch.all(dist(X, Y) == res), f"{dist(X, Y)} :: {res}"
 
 
-def test_svd_sensitive_subspace_distance():
+@pytest.mark.parametrize(
+    "itemwise_dist",
+    [(False), (True)],
+)
+def test_svd_sensitive_subspace_distance(itemwise_dist):
 
     n_samples = 10
     n_features = 50
@@ -72,16 +76,26 @@ def test_svd_sensitive_subspace_distance():
     metric = distances.SVDSensitiveSubspaceDistance()
     metric.fit(X_train, n_components)
 
-    dist = metric(X1, X2)
-    assert list(dist.shape) == [n_samples, 1]
-    assert dist.requires_grad == True
+    dist = metric(X1, X2, itemwise_dist)
 
-    dist = metric(X1, X1)
-    assert torch.all(dist == 0)
-    assert dist.requires_grad == True
+    if itemwise_dist:
+        assert list(dist.shape) == [n_samples, 1]
+        assert dist.requires_grad == True
+    else:
+        assert list(dist.shape) == [1, n_samples, n_samples]
+        assert dist.requires_grad == True
+
+    if itemwise_dist:
+        dist = metric(X1, X1, itemwise_dist)
+        assert torch.all(dist == 0)
+        assert dist.requires_grad == True
 
 
-def test_svd_sensitive_subspace_distance_multiple_similar_data():
+@pytest.mark.parametrize(
+    "itemwise_dist",
+    [(False), (True)],
+)
+def test_svd_sensitive_subspace_distance_multiple_similar_data(itemwise_dist):
 
     n_samples = 10
     n_features = 50
@@ -96,13 +110,19 @@ def test_svd_sensitive_subspace_distance_multiple_similar_data():
     metric = distances.SVDSensitiveSubspaceDistance()
     metric.fit(X_train, n_components)
 
-    dist = metric(X1, X2)
-    assert list(dist.shape) == [n_samples, 1]
-    assert dist.requires_grad == True
+    dist = metric(X1, X2, itemwise_dist)
 
-    dist = metric(X1, X1)
-    assert torch.all(dist == 0)
-    assert dist.requires_grad == True
+    if itemwise_dist:
+        assert list(dist.shape) == [n_samples, 1]
+        assert dist.requires_grad == True
+    else:
+        assert list(dist.shape) == [1, n_samples, n_samples]
+        assert dist.requires_grad == True
+
+    if itemwise_dist:
+        dist = metric(X1, X1, itemwise_dist)
+        assert torch.all(dist == 0)
+        assert dist.requires_grad == True
 
 
 def test_svd_sensitive_subspace_distance_raises_error():
@@ -114,7 +134,11 @@ def test_svd_sensitive_subspace_distance_raises_error():
         metric.fit(X_train, n_components)
 
 
-def test_explore_sensitive_subspace_distance():
+@pytest.mark.parametrize(
+    "itemwise_dist",
+    [(False), (True)],
+)
+def test_explore_sensitive_subspace_distance(itemwise_dist):
 
     n_features = 50
 
@@ -129,13 +153,19 @@ def test_explore_sensitive_subspace_distance():
     metric = distances.EXPLOREDistance()
     metric.fit(X1, X2, Y, iters=100, batchsize=8)
 
-    dist = metric(X1, X2)
-    assert list(dist.shape) == [n_samples, 1]
-    assert dist.requires_grad == True
+    dist = metric(X1, X2, itemwise_dist)
 
-    dist = metric(X1, X1)
-    assert torch.all(dist == 0)
-    assert dist.requires_grad == True
+    if itemwise_dist:
+        assert list(dist.shape) == [n_samples, 1]
+        assert dist.requires_grad == True
+    else:
+        assert list(dist.shape) == [1, n_samples, n_samples]
+        assert dist.requires_grad == True
+
+    if itemwise_dist:
+        dist = metric(X1, X1, itemwise_dist)
+        assert torch.all(dist == 0)
+        assert dist.requires_grad == True
 
 
 def test_squared_euclidean_distance():
@@ -144,10 +174,10 @@ def test_squared_euclidean_distance():
     dist = distances.SquaredEuclideanDistance()
     dist.fit(num_dims=2)
 
-    distx1x2 = dist(x1, x2)
+    distx1x2 = dist(x1, x2, True)
     assert distx1x2.item() == 8
 
-    distx1x1 = dist(x1, x1)
+    distx1x1 = dist(x1, x1, True)
     assert distx1x1 == 0
 
 


### PR DESCRIPTION
Currently, Mahalanobis distance is built to compute item-wise distances, but we require pair-wise distances for (a) ranking and (b) postprocessing. This PR adds support for computing both item-wise and pair-wise distances.