### PR TITLE
add saving and loading infairness component state to disk

### DIFF
--- a/inFairness/distances/distance.py
+++ b/inFairness/distances/distance.py
@@ -19,6 +19,16 @@ class Distance(nn.Module, metaclass=ABCMeta):
         """
         pass
 
+    def load_state_dict(self, state_dict, strict=True):
+
+        buffer_keys = [bufferitem[0] for bufferitem in self.named_buffers()]
+        for key, val in state_dict.items():
+            if key not in buffer_keys and strict:
+                raise AssertionError(
+                    f"{key} not found in metric state and strict parameter is set to True. Either set strict parameter to False or remove extra entries from the state dictionary."
+                )
+            setattr(self, key, val)
+
     @abstractmethod
     def forward(self, x, y):
         """

--- a/inFairness/distances/euclidean_dists.py
+++ b/inFairness/distances/euclidean_dists.py
@@ -21,7 +21,7 @@ class ProtectedEuclideanDistance(Distance):
 
         self._protected_attributes = None
         self._num_attributes = None
-        self.protected_vector = None
+        self.register_buffer("protected_vector", torch.Tensor())
 
     def to(self, device):
         """Moves distance metric to a particular device
@@ -32,7 +32,7 @@ class ProtectedEuclideanDistance(Distance):
         """
 
         assert (
-            self.protected_vector is not None
+            self.protected_vector is not None and len(self.protected_vector.size()) != 0
         ), "Please fit the metric before moving parameters to device"
 
         self.device = device

--- a/inFairness/distances/explore_distance.py
+++ b/inFairness/distances/explore_distance.py
@@ -55,6 +55,9 @@ class EXPLOREDistance(MahalanobisDistances):
                 on CPU.
         """
 
+        assert (
+            X1.shape[0] == X2.shape[0] == Y.shape[0]
+        ), "Number of elements in X1, X2, and Y do not match"
         X = datautils.convert_tensor_to_numpy(X1 - X2)
         Y = datautils.convert_tensor_to_numpy(Y)
         sigma = self.compute_sigma(X, Y, iters, batchsize)

--- a/inFairness/distances/mahalanobis_distance.py
+++ b/inFairness/distances/mahalanobis_distance.py
@@ -16,10 +16,9 @@ class MahalanobisDistances(Distance):
     def __init__(self):
         super().__init__()
 
-        self.sigma = None
         self.device = torch.device("cpu")
         self._vectorized_dist = None
-        
+        self.register_buffer("sigma", torch.Tensor())
 
     def to(self, device):
         """Moves distance metric to a particular device
@@ -30,7 +29,7 @@ class MahalanobisDistances(Distance):
         """
 
         assert (
-            self.sigma is not None
+            self.sigma is not None or len(self.sigma.size()) == 0
         ), "Please fit the metric before moving parameters to device"
 
         self.device = device
@@ -136,6 +135,10 @@ class MahalanobisDistances(Distance):
             dist = self._vectorized_dist(X1, X2, self.sigma).view(dist_shape)
 
         return dist
+
+    def load_state_dict(self, state_dict, strict = True):
+        for key, val in state_dict.items():
+            setattr(self, key, val)
 
 
 class SquaredEuclideanDistance(MahalanobisDistances):

--- a/inFairness/distances/mahalanobis_distance.py
+++ b/inFairness/distances/mahalanobis_distance.py
@@ -29,7 +29,7 @@ class MahalanobisDistances(Distance):
         """
 
         assert (
-            self.sigma is not None or len(self.sigma.size()) == 0
+            self.sigma is not None and len(self.sigma.size()) != 0
         ), "Please fit the metric before moving parameters to device"
 
         self.device = device
@@ -135,10 +135,6 @@ class MahalanobisDistances(Distance):
             dist = self._vectorized_dist(X1, X2, self.sigma).view(dist_shape)
 
         return dist
-
-    def load_state_dict(self, state_dict, strict = True):
-        for key, val in state_dict.items():
-            setattr(self, key, val)
 
 
 class SquaredEuclideanDistance(MahalanobisDistances):

--- a/tests/distances/test_common_distances.py
+++ b/tests/distances/test_common_distances.py
@@ -141,14 +141,11 @@ def test_svd_sensitive_subspace_distance_raises_error():
 def test_explore_sensitive_subspace_distance(itemwise_dist):
 
     n_features = 50
-
-    X1 = torch.rand((100, n_features))
-    X2 = torch.rand((100, n_features))
-    Y = torch.randint(low=0, high=2, size=(100,))
-
-    n_samples = 10
+    n_samples = 100
+    
     X1 = torch.rand((n_samples, n_features)).requires_grad_()
     X2 = torch.rand((n_samples, n_features)).requires_grad_()
+    Y = torch.randint(low=0, high=2, size=(n_samples,))
 
     metric = distances.EXPLOREDistance()
     metric.fit(X1, X2, Y, iters=100, batchsize=8)

--- a/tests/distances/test_distance_state.py
+++ b/tests/distances/test_distance_state.py
@@ -38,3 +38,119 @@ def test_mahalanobis_dist_state_update():
     state_dict1 = dist1.state_dict()
     assert "sigma" in state_dict1
     assert torch.all(state_dict1["sigma"] == sigma)
+
+
+def test_squared_euclidean_dist_state():
+
+    dist = distances.SquaredEuclideanDistance()
+    dist.fit(num_dims=5)
+
+    state_dict = dist.state_dict()
+    assert "sigma" in state_dict
+    assert torch.all(torch.eye(5) == state_dict["sigma"])
+
+
+def test_protected_euclidean_dist_state():
+
+    protected_attrs = [1]
+    num_attrs = 3
+
+    dist = distances.ProtectedEuclideanDistance()
+    dist.fit(protected_attrs, num_attrs)
+
+    protected_vec = torch.ones(num_attrs)
+    protected_vec[protected_attrs] = 0.0
+
+    state_dict = dist.state_dict()
+    assert "protected_vector" in state_dict
+    assert torch.all(protected_vec == state_dict["protected_vector"])
+
+
+def test_svd_distance_state():
+
+    n_features = 50
+    n_components = 10
+
+    X_train = torch.rand((100, n_features))
+
+    metric = distances.SVDSensitiveSubspaceDistance()
+    metric.fit(X_train, n_components)
+
+    state = metric.state_dict()
+    assert "sigma" in state
+    sigma = state["sigma"]
+    assert sigma.shape == (n_features, n_features)
+
+    metric_new = distances.SVDSensitiveSubspaceDistance()
+    metric_new.load_state_dict(state)
+    new_state = metric_new.state_dict()
+    assert torch.all(new_state["sigma"] == sigma)
+
+
+def test_explore_distance_state():
+
+    n_features = 50
+    n_samples = 100
+    
+    X1 = torch.rand((n_samples, n_features)).requires_grad_()
+    X2 = torch.rand((n_samples, n_features)).requires_grad_()
+    Y = torch.randint(low=0, high=2, size=(n_samples,))
+
+    metric = distances.EXPLOREDistance()
+    metric.fit(X1, X2, Y, iters=100, batchsize=8)
+
+    state = metric.state_dict()
+    assert "sigma" in state
+    sigma = state["sigma"]
+    assert sigma.shape == (n_features, n_features)
+
+    metric_new = distances.EXPLOREDistance()
+    metric_new.load_state_dict(state)
+    new_state = metric_new.state_dict()
+    assert torch.all(new_state["sigma"] == sigma)
+
+
+def test_logreg_distance_state():
+
+    n_samples, n_features = 100, 3
+    X_train = torch.rand(size=(n_samples, n_features))
+    mean = X_train.mean(dim=0, keepdim=True)
+    std = X_train.std(dim=0, keepdim=True)
+    X_train = (X_train - mean) / std
+
+    protected_attr = torch.randint(low=0, high=2, size=(n_samples, 1))
+
+    X_train[:, 0:1] += protected_attr
+    X_train = torch.hstack((X_train, protected_attr))
+
+    metric = distances.LogisticRegSensitiveSubspace()
+    metric.fit(X_train, protected_idxs=[3])
+
+    state = metric.state_dict()
+    assert "sigma" in state
+    sigma = state["sigma"]
+    assert sigma.shape == (n_features+1, n_features+1)
+
+    metric_new = distances.EXPLOREDistance()
+    metric_new.load_state_dict(state)
+    new_state = metric_new.state_dict()
+    assert torch.all(new_state["sigma"] == sigma)
+
+
+def test_wasserstein_dist_state():
+
+    squared_euclidean = distances.SquaredEuclideanDistance()
+    squared_euclidean.fit(num_dims=2)
+    sigma = squared_euclidean.sigma
+
+    wasserstein_dist = distances.WassersteinDistance()
+    wasserstein_dist.fit(sigma)
+
+    state = wasserstein_dist.state_dict()
+    assert "sigma" in state
+    assert torch.all(state["sigma"] == sigma)
+
+    metric_new = distances.WassersteinDistance()
+    metric_new.load_state_dict(state)
+    new_state = metric_new.state_dict()
+    assert torch.all(new_state["sigma"] == sigma)

--- a/tests/distances/test_distance_state.py
+++ b/tests/distances/test_distance_state.py
@@ -1,0 +1,40 @@
+import pytest
+import torch
+
+from inFairness import distances
+
+
+def test_mahalanobis_dist_state_buffer_set():
+
+    dist = distances.MahalanobisDistances()
+    sigma = torch.rand(size=(10, 10))
+    dist.fit(sigma)
+
+    state_dict = dist.state_dict()
+    assert "sigma" in state_dict
+    assert torch.all(state_dict["sigma"] == sigma)
+
+    sigma = torch.rand(size=(10, 10))
+    dist.fit(sigma)
+
+    state_dict = dist.state_dict()
+    assert "sigma" in state_dict
+    assert torch.all(state_dict["sigma"] == sigma)
+
+
+def test_mahalanobis_dist_state_update():
+
+    dist = distances.MahalanobisDistances()
+    sigma = torch.rand(size=(10, 10))
+    dist.fit(sigma)
+
+    state_dict = dist.state_dict()
+    assert  "sigma" in state_dict
+    assert torch.all(state_dict["sigma"] == sigma)
+
+    dist1 = distances.MahalanobisDistances()
+    dist1.load_state_dict(state_dict)
+    
+    state_dict1 = dist1.state_dict()
+    assert "sigma" in state_dict1
+    assert torch.all(state_dict1["sigma"] == sigma)


### PR DESCRIPTION
fixes #56 

This PR adds support for saving and loading trained distance metrics to disk. The format is the same as PyTorch modules, like:

```
dist = distances.SVDSensitiveSubspaceDistance()   # can be any metric
dist.fit(*args, **kwargs)

# saving state to disk
state = dist.state_dict()
torch.save(state, PATH)

# load state from disk
state = torch.load(PATH)
dist = distances.SVDSensitiveSubspaceDistance()
dist.load_state_dict(state)
```

Refer: https://pytorch.org/tutorials/beginner/saving_loading_models.html#saving-loading-model-for-inference