### PR TITLE
Update adult income prediction notebook

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -3,7 +3,7 @@
 #### Auditing models for Individual Fairness
 | Task      | Auditor | Fair Metrics |  |
 | ----------- | ----------- | ----------- | ----------- |
-| Adult Income Prediction      | [SenSeI](https://ibm.github.io/inFairness/reference/auditors.html#sensei-auditor), [SenSR](https://ibm.github.io/inFairness/reference/auditors.html#sensr-auditor) |  [LogisticRegSensitiveSubspace](https://ibm.github.io/inFairness/reference/distances.html#logistic-regression-sensitive-subspace-distance-metric) |  [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/ibm/infairness/main?labpath=examples%2Fadult-income-prediction%2Fadult_income_prediction.ipynb)     |
+| Adult Income Prediction      | [SenSR](https://ibm.github.io/inFairness/reference/auditors.html#sensr-auditor) |  [LogisticRegSensitiveSubspace](https://ibm.github.io/inFairness/reference/distances.html#logistic-regression-sensitive-subspace-distance-metric) [EXPLOREDistance](https://ibm.github.io/inFairness/reference/distances.html#explore-embedded-xenial-pairs-logistic-regression) |  [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/ibm/infairness/main?labpath=examples%2Fadult-income-prediction%2Fadult_income_prediction.ipynb)     |
 | Sentiment Analysis   | [SenSR](https://ibm.github.io/inFairness/reference/auditors.html#sensr-auditor) | [SVDSensitiveSubspaceDistance](https://ibm.github.io/inFairness/reference/distances.html#svd-sensitive-subspace) |  [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/ibm/infairness/main?labpath=examples%2Fsentiment-analysis%2Fsentiment_analysis_demo.ipynb)    |
 
 -------

--- a/examples/adult-income-prediction/adult_income_prediction.ipynb
+++ b/examples/adult-income-prediction/adult_income_prediction.ipynb
@@ -12,14 +12,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/Users/mayank.agarwal@ibm.com/anaconda3/envs/infairness_notebook/lib/python3.8/site-packages/tqdm/auto.py:22: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html\n",
+      "/Users/mayank/opt/anaconda3/envs/infairness/lib/python3.8/site-packages/tqdm/auto.py:22: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html\n",
       "  from .autonotebook import tqdm as notebook_tqdm\n"
      ]
     }
@@ -46,7 +46,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -66,7 +66,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
@@ -101,9 +101,9 @@
        "      <th>marital-status_Married-spouse-absent</th>\n",
        "      <th>marital-status_Never-married</th>\n",
        "      <th>...</th>\n",
+       "      <th>relationship_Own-child</th>\n",
        "      <th>relationship_Unmarried</th>\n",
        "      <th>relationship_Wife</th>\n",
-       "      <th>sex_Male</th>\n",
        "      <th>workclass_Federal-gov</th>\n",
        "      <th>workclass_Local-gov</th>\n",
        "      <th>workclass_Private</th>\n",
@@ -127,8 +127,8 @@
        "      <td>0</td>\n",
        "      <td>1</td>\n",
        "      <td>...</td>\n",
-       "      <td>1</td>\n",
        "      <td>0</td>\n",
+       "      <td>1</td>\n",
        "      <td>0</td>\n",
        "      <td>0</td>\n",
        "      <td>0</td>\n",
@@ -151,7 +151,7 @@
        "      <td>0</td>\n",
        "      <td>1</td>\n",
        "      <td>...</td>\n",
-       "      <td>0</td>\n",
+       "      <td>1</td>\n",
        "      <td>0</td>\n",
        "      <td>0</td>\n",
        "      <td>0</td>\n",
@@ -177,7 +177,7 @@
        "      <td>...</td>\n",
        "      <td>0</td>\n",
        "      <td>0</td>\n",
-       "      <td>1</td>\n",
+       "      <td>0</td>\n",
        "      <td>0</td>\n",
        "      <td>1</td>\n",
        "      <td>0</td>\n",
@@ -201,7 +201,7 @@
        "      <td>...</td>\n",
        "      <td>0</td>\n",
        "      <td>0</td>\n",
-       "      <td>1</td>\n",
+       "      <td>0</td>\n",
        "      <td>0</td>\n",
        "      <td>0</td>\n",
        "      <td>1</td>\n",
@@ -225,7 +225,7 @@
        "      <td>...</td>\n",
        "      <td>0</td>\n",
        "      <td>0</td>\n",
-       "      <td>1</td>\n",
+       "      <td>0</td>\n",
        "      <td>0</td>\n",
        "      <td>0</td>\n",
        "      <td>0</td>\n",
@@ -236,7 +236,7 @@
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
-       "<p>5 rows × 41 columns</p>\n",
+       "<p>5 rows × 39 columns</p>\n",
        "</div>"
       ],
       "text/plain": [
@@ -261,38 +261,38 @@
        "3                                  1                                     0   \n",
        "4                                  1                                     0   \n",
        "\n",
-       "   marital-status_Never-married  ...  relationship_Unmarried  \\\n",
-       "0                             1  ...                       1   \n",
-       "1                             1  ...                       0   \n",
+       "   marital-status_Never-married  ...  relationship_Own-child  \\\n",
+       "0                             1  ...                       0   \n",
+       "1                             1  ...                       1   \n",
        "2                             0  ...                       0   \n",
        "3                             0  ...                       0   \n",
        "4                             0  ...                       0   \n",
        "\n",
-       "   relationship_Wife  sex_Male  workclass_Federal-gov  workclass_Local-gov  \\\n",
-       "0                  0         0                      0                    0   \n",
-       "1                  0         0                      0                    0   \n",
-       "2                  0         1                      0                    1   \n",
-       "3                  0         1                      0                    0   \n",
-       "4                  0         1                      0                    0   \n",
+       "   relationship_Unmarried  relationship_Wife  workclass_Federal-gov  \\\n",
+       "0                       1                  0                      0   \n",
+       "1                       0                  0                      0   \n",
+       "2                       0                  0                      0   \n",
+       "3                       0                  0                      0   \n",
+       "4                       0                  0                      0   \n",
        "\n",
-       "   workclass_Private  workclass_Self-emp-inc  workclass_Self-emp-not-inc  \\\n",
-       "0                  1                       0                           0   \n",
-       "1                  1                       0                           0   \n",
-       "2                  0                       0                           0   \n",
-       "3                  1                       0                           0   \n",
-       "4                  0                       0                           1   \n",
+       "   workclass_Local-gov  workclass_Private  workclass_Self-emp-inc  \\\n",
+       "0                    0                  1                       0   \n",
+       "1                    0                  1                       0   \n",
+       "2                    1                  0                       0   \n",
+       "3                    0                  1                       0   \n",
+       "4                    0                  0                       0   \n",
        "\n",
-       "   workclass_State-gov  workclass_Without-pay  \n",
-       "0                    0                      0  \n",
-       "1                    0                      0  \n",
-       "2                    0                      0  \n",
-       "3                    0                      0  \n",
-       "4                    0                      0  \n",
+       "   workclass_Self-emp-not-inc  workclass_State-gov  workclass_Without-pay  \n",
+       "0                           0                    0                      0  \n",
+       "1                           0                    0                      0  \n",
+       "2                           0                    0                      0  \n",
+       "3                           0                    0                      0  \n",
+       "4                           1                    0                      0  \n",
        "\n",
-       "[5 rows x 41 columns]"
+       "[5 rows x 39 columns]"
       ]
      },
-     "execution_count": 4,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -303,6 +303,14 @@
     "X_train_df, Y_train_df = train_df\n",
     "X_test_df, Y_test_df = test_df\n",
     "\n",
+    "# Let's drop the protected attributes from the training and test data and store them in a\n",
+    "# separate dataframe that we'll use later to train the individually fair metric.\n",
+    "protected_vars = ['race_White', 'sex_Male']\n",
+    "\n",
+    "X_protected_df = X_train_df[protected_vars]\n",
+    "X_train_df = X_train_df.drop(columns=protected_vars)\n",
+    "X_test_df = X_test_df.drop(columns=protected_vars)\n",
+    "\n",
     "# Create test data with spouse variable flipped\n",
     "X_test_df_spouse_flipped = X_test_df.copy()\n",
     "X_test_df_spouse_flipped.relationship_Wife = 1 - X_test_df_spouse_flipped.relationship_Wife\n",
@@ -312,18 +320,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
     "device = torch.device('cpu')\n",
     "\n",
-    "protected_vars = ['race_White', 'sex_Male']\n",
-    "protected_idxs = [X_train_df.columns.get_loc(var) for var in protected_vars]\n",
-    "\n",
+    "# Convert all pandas dataframes to PyTorch tensors\n",
     "X_train, y_train = data.convert_df_to_tensor(X_train_df, Y_train_df)\n",
     "X_test, y_test = data.convert_df_to_tensor(X_test_df, Y_test_df)\n",
     "X_test_flip, y_test_flip = data.convert_df_to_tensor(X_test_df_spouse_flipped, Y_test_df)\n",
+    "X_protected = torch.tensor(X_protected_df.values).float()\n",
     "\n",
     "# Create the training and testing dataset\n",
     "train_ds = AdultDataset(X_train, y_train)\n",
@@ -338,7 +345,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -370,7 +377,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -386,14 +393,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 10/10 [00:08<00:00,  1.20it/s]\n"
+      "100%|██████████| 10/10 [00:03<00:00,  2.57it/s]\n"
      ]
     }
    ],
@@ -414,16 +421,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Accuracy: 0.855373740196228\n",
-      "Balanced accuracy: 0.7758295636205936\n",
-      "Spouse consistency: 0.9483635559486953\n"
+      "Accuracy: 0.855042040348053\n",
+      "Balanced accuracy: 0.7806884556970295\n",
+      "Spouse consistency: 0.9593100398053959\n"
      ]
     }
    ],
@@ -441,27 +448,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Individually fair training"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 10,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "network_fair = Model(input_size, output_size).to(device)\n",
-    "optimizer = torch.optim.Adam(network_fair.parameters(), lr=1e-3)\n",
-    "lossfn = F.cross_entropy\n",
-    "\n",
-    "distance_x = distances.LogisticRegSensitiveSubspace()\n",
-    "distance_y = distances.SquaredEuclideanDistance()\n",
-    "\n",
-    "distance_x.fit(X_train, protected_idxs=protected_idxs)\n",
-    "distance_y.fit(num_dims=output_size)\n",
-    "\n",
-    "distance_x.to(device)\n",
-    "distance_y.to(device)"
+    "### Individually fair training with LogReg fair metric"
    ]
   },
   {
@@ -470,37 +457,32 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "rho = 5.0\n",
-    "eps = 0.1\n",
-    "auditor_nsteps = 100\n",
-    "auditor_lr = 1e-3\n",
+    "network_fair_LR = Model(input_size, output_size).to(device)\n",
+    "optimizer = torch.optim.Adam(network_fair_LR.parameters(), lr=1e-3)\n",
+    "lossfn = F.cross_entropy\n",
     "\n",
-    "fairalgo = SenSeI(network_fair, distance_x, distance_y, lossfn, rho, eps, auditor_nsteps, auditor_lr)"
+    "distance_x_LR = distances.LogisticRegSensitiveSubspace()\n",
+    "distance_y = distances.SquaredEuclideanDistance()\n",
+    "\n",
+    "distance_x_LR.fit(X_train, data_SensitiveAttrs=X_protected)\n",
+    "distance_y.fit(num_dims=output_size)\n",
+    "\n",
+    "distance_x_LR.to(device)\n",
+    "distance_y.to(device)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 12,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "100%|██████████| 10/10 [08:18<00:00, 49.90s/it]\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "fairalgo.train()\n",
+    "rho = 5.0\n",
+    "eps = 0.1\n",
+    "auditor_nsteps = 100\n",
+    "auditor_lr = 1e-3\n",
     "\n",
-    "for epoch in tqdm(range(EPOCHS)):\n",
-    "    for x, y in train_dl:\n",
-    "        x, y = x.to(device), y.to(device)\n",
-    "        optimizer.zero_grad()\n",
-    "        result = fairalgo(x, y)\n",
-    "        result.loss.backward()\n",
-    "        optimizer.step()"
+    "fairalgo_LR = SenSeI(network_fair_LR, distance_x_LR, distance_y, lossfn, rho, eps, auditor_nsteps, auditor_lr)"
    ]
   },
   {
@@ -509,19 +491,44 @@
    "metadata": {},
    "outputs": [
     {
-     "name": "stdout",
+     "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Accuracy: 0.8373507261276245\n",
-      "Balanced accuracy: 0.7335829237002883\n",
-      "Spouse consistency: 0.9997788589119858\n"
+      "100%|██████████| 10/10 [03:02<00:00, 18.29s/it]\n"
      ]
     }
    ],
    "source": [
-    "accuracy = metrics.accuracy(network_fair, test_dl, device)\n",
-    "balanced_acc = metrics.balanced_accuracy(network_fair, test_dl, device)\n",
-    "spouse_consistency = metrics.spouse_consistency(network_fair, test_dl, test_dl_flip, device)\n",
+    "fairalgo_LR.train()\n",
+    "\n",
+    "for epoch in tqdm(range(EPOCHS)):\n",
+    "    for x, y in train_dl:\n",
+    "        x, y = x.to(device), y.to(device)\n",
+    "        optimizer.zero_grad()\n",
+    "        result = fairalgo_LR(x, y)\n",
+    "        result.loss.backward()\n",
+    "        optimizer.step()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Accuracy: 0.8369084596633911\n",
+      "Balanced accuracy: 0.7357549314737899\n",
+      "Spouse consistency: 0.9998894294559929\n"
+     ]
+    }
+   ],
+   "source": [
+    "accuracy = metrics.accuracy(network_fair_LR, test_dl, device)\n",
+    "balanced_acc = metrics.balanced_accuracy(network_fair_LR, test_dl, device)\n",
+    "spouse_consistency = metrics.spouse_consistency(network_fair_LR, test_dl, test_dl_flip, device)\n",
     "\n",
     "print(f'Accuracy: {accuracy}')\n",
     "print(f'Balanced accuracy: {balanced_acc}')\n",
@@ -532,52 +539,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### Let's now audit the two models and check for their individua fairness compliance"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 14,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/mayank.agarwal@ibm.com/anaconda3/envs/infairness_notebook/lib/python3.8/site-packages/inFairness/auditor/auditor.py:54: RuntimeWarning: invalid value encountered in true_divide\n",
-      "  loss_ratio = np.divide(loss_vals_adversarial, loss_vals_original)\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "====================================================================================================\n",
-      "Loss ratio (Standard model) : 2.930340963480738. Is model fair: False\n",
-      "Loss ratio (fair model) : 1.045007604621082. Is model fair: True\n",
-      "----------------------------------------------------------------------------------------------------\n",
-      "\t As signified by these numbers, the fair model is fairer than the standard model\n",
-      "====================================================================================================\n"
-     ]
-    }
-   ],
-   "source": [
-    "# Auditing using the SenSR Auditor\n",
-    "\n",
-    "audit_nsteps = 1000\n",
-    "audit_lr = 0.1\n",
-    "\n",
-    "auditor = SenSRAuditor(loss_fn=loss_fn, distance_x=distance_x, num_steps=audit_nsteps, lr=audit_lr, max_noise=0.5, min_noise=-0.5)\n",
-    "\n",
-    "audit_result_stdmodel = auditor.audit(network_standard, X_test, y_test, lambda_param=10.0, audit_threshold=1.15)\n",
-    "audit_result_fairmodel = auditor.audit(network_fair, X_test, y_test, lambda_param=10.0, audit_threshold=1.15)\n",
-    "\n",
-    "print(\"=\"*100)\n",
-    "print(f\"Loss ratio (Standard model) : {audit_result_stdmodel.lower_bound}. Is model fair: {audit_result_stdmodel.is_model_fair}\")\n",
-    "print(f\"Loss ratio (fair model) : {audit_result_fairmodel.lower_bound}. Is model fair: {audit_result_fairmodel.is_model_fair}\")\n",
-    "print(\"-\"*100)\n",
-    "print(\"\\t As signified by these numbers, the fair model is fairer than the standard model\")\n",
-    "print(\"=\"*100)"
+    "### Individually fair training with EXPLORE metric"
    ]
   },
   {
@@ -586,34 +548,187 @@
    "metadata": {},
    "outputs": [
     {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/mayank/Documents/[Projects]/open-source/inFairness/examples/adult-income-prediction/../../inFairness/distances/explore_distance.py:76: RuntimeWarning: overflow encountered in exp\n",
+      "  sclVec = 2.0 / (np.exp(diag) - 1)\n"
+     ]
+    }
+   ],
+   "source": [
+    "Y_gender = X_protected[:, -1]\n",
+    "X1, X2, Y_pairs = data.create_data_pairs(X_train, y_train, Y_gender)\n",
+    "\n",
+    "distance_x_explore = distances.EXPLOREDistance()\n",
+    "distance_x_explore.fit(X1, X2, Y_pairs, iters=1000, batchsize=10000)\n",
+    "distance_x_explore.to(device)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "network_fair_explore = Model(input_size, output_size).to(device)\n",
+    "optimizer = torch.optim.Adam(network_fair_explore.parameters(), lr=1e-3)\n",
+    "lossfn = F.cross_entropy\n",
+    "\n",
+    "rho = 25.0\n",
+    "eps = 0.1\n",
+    "auditor_nsteps = 10\n",
+    "auditor_lr = 1e-2\n",
+    "\n",
+    "fairalgo_explore = SenSeI(network_fair_explore, distance_x_explore, distance_y, lossfn, rho, eps, auditor_nsteps, auditor_lr)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████| 10/10 [00:24<00:00,  2.42s/it]\n"
+     ]
+    }
+   ],
+   "source": [
+    "fairalgo_explore.train()\n",
+    "\n",
+    "for epoch in tqdm(range(EPOCHS)):\n",
+    "    for x, y in train_dl:\n",
+    "        x, y = x.to(device), y.to(device)\n",
+    "        optimizer.zero_grad()\n",
+    "        result = fairalgo_explore(x, y)\n",
+    "        result.loss.backward()\n",
+    "        optimizer.step()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Accuracy: 0.8224236965179443\n",
+      "Balanced accuracy: 0.6999390313607438\n",
+      "Spouse consistency: 0.9997788589119858\n"
+     ]
+    }
+   ],
+   "source": [
+    "accuracy = metrics.accuracy(network_fair_explore, test_dl, device)\n",
+    "balanced_acc = metrics.balanced_accuracy(network_fair_explore, test_dl, device)\n",
+    "spouse_consistency = metrics.spouse_consistency(network_fair_explore, test_dl, test_dl_flip, device)\n",
+    "\n",
+    "print(f'Accuracy: {accuracy}')\n",
+    "print(f'Balanced accuracy: {balanced_acc}')\n",
+    "print(f'Spouse consistency: {spouse_consistency}')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Let's now audit the three models and check for their individual fairness compliance"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/mayank/Documents/[Projects]/open-source/inFairness/examples/adult-income-prediction/../../inFairness/auditor/auditor.py:54: RuntimeWarning: invalid value encountered in divide\n",
+      "  loss_ratio = np.divide(loss_vals_adversarial, loss_vals_original)\n"
+     ]
+    },
+    {
      "name": "stdout",
      "output_type": "stream",
      "text": [
       "====================================================================================================\n",
-      "Loss ratio (Standard model) : 238.7647221454322. Is model fair: False\n",
-      "Loss ratio (fair model) : 1.0002661858231792. Is model fair: True\n",
+      "LR metric\n",
+      "Loss ratio (Standard model) : 2.4822924476956905. Is model fair: False\n",
+      "Loss ratio (fair model - LogReg metric) : 1.0421434064879227. Is model fair: True\n",
+      "Loss ratio (fair model - EXPLORE metric) : 1.026998276114377. Is model fair: True\n",
       "----------------------------------------------------------------------------------------------------\n",
-      "\t As signified by these numbers, the fair model is fairer than the standard model\n",
+      "\t As signified by these numbers, the fair models are fairer than the standard model\n",
       "====================================================================================================\n"
      ]
     }
    ],
    "source": [
-    "# Auditing using the SenSeI Auditor\n",
+    "# Auditing using the SenSR Auditor + LR metric\n",
     "\n",
-    "audit_nsteps = 500\n",
-    "audit_lr = 0.001\n",
+    "audit_nsteps = 1000\n",
+    "audit_lr = 0.1\n",
     "\n",
-    "auditor = SenSeIAuditor(distance_x=distance_x, distance_y=distance_y, num_steps=audit_nsteps, lr=audit_lr, max_noise=0.5, min_noise=-0.5)\n",
+    "auditor_LR = SenSRAuditor(loss_fn=loss_fn, distance_x=distance_x_LR, num_steps=audit_nsteps, lr=audit_lr, max_noise=0.5, min_noise=-0.5)\n",
     "\n",
-    "audit_result_stdmodel = auditor.audit(network_standard, X_test, y_test, loss_fn, audit_threshold=1.15, lambda_param=50.0)\n",
-    "audit_result_fairmodel = auditor.audit(network_fair, X_test, y_test, loss_fn, audit_threshold=1.15, lambda_param=50.0)\n",
+    "audit_result_stdmodel = auditor_LR.audit(network_standard, X_test, y_test, lambda_param=10.0, audit_threshold=1.15)\n",
+    "audit_result_fairmodel_LR = auditor_LR.audit(network_fair_LR, X_test, y_test, lambda_param=10.0, audit_threshold=1.15)\n",
+    "audit_result_fairmodel_explore = auditor_LR.audit(network_fair_explore, X_test, y_test, lambda_param=10.0, audit_threshold=1.15)\n",
     "\n",
     "print(\"=\"*100)\n",
+    "print(\"LR metric\")\n",
     "print(f\"Loss ratio (Standard model) : {audit_result_stdmodel.lower_bound}. Is model fair: {audit_result_stdmodel.is_model_fair}\")\n",
-    "print(f\"Loss ratio (fair model) : {audit_result_fairmodel.lower_bound}. Is model fair: {audit_result_fairmodel.is_model_fair}\")\n",
+    "print(f\"Loss ratio (fair model - LogReg metric) : {audit_result_fairmodel_LR.lower_bound}. Is model fair: {audit_result_fairmodel_LR.is_model_fair}\")\n",
+    "print(f\"Loss ratio (fair model - EXPLORE metric) : {audit_result_fairmodel_explore.lower_bound}. Is model fair: {audit_result_fairmodel_explore.is_model_fair}\")\n",
     "print(\"-\"*100)\n",
-    "print(\"\\t As signified by these numbers, the fair model is fairer than the standard model\")\n",
+    "print(\"\\t As signified by these numbers, the fair models are fairer than the standard model\")\n",
+    "print(\"=\"*100)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "====================================================================================================\n",
+      "EXPLORE metric\n",
+      "Loss ratio (Standard model) : 3.2874276326186633. Is model fair: False\n",
+      "Loss ratio (fair model - LogReg metric) : 1.0897408117340435. Is model fair: True\n",
+      "Loss ratio (fair model - EXPLORE metric) : 1.063488311922447. Is model fair: True\n",
+      "----------------------------------------------------------------------------------------------------\n",
+      "\t As signified by these numbers, the fair models are fairer than the standard model\n",
+      "====================================================================================================\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Auditing using the SenSR Auditor + EXPLORE metric\n",
+    "\n",
+    "audit_nsteps = 1000\n",
+    "audit_lr = 0.1\n",
+    "\n",
+    "auditor_explore = SenSRAuditor(loss_fn=loss_fn, distance_x=distance_x_explore, num_steps=audit_nsteps, lr=audit_lr, max_noise=0.5, min_noise=-0.5)\n",
+    "\n",
+    "audit_result_stdmodel = auditor_explore.audit(network_standard, X_test, y_test, lambda_param=10.0, audit_threshold=1.15)\n",
+    "audit_result_fairmodel_LR = auditor_explore.audit(network_fair_LR, X_test, y_test, lambda_param=10.0, audit_threshold=1.15)\n",
+    "audit_result_fairmodel_explore = auditor_explore.audit(network_fair_explore, X_test, y_test, lambda_param=10.0, audit_threshold=1.15)\n",
+    "\n",
+    "print(\"=\"*100)\n",
+    "print(\"EXPLORE metric\")\n",
+    "print(f\"Loss ratio (Standard model) : {audit_result_stdmodel.lower_bound}. Is model fair: {audit_result_stdmodel.is_model_fair}\")\n",
+    "print(f\"Loss ratio (fair model - LogReg metric) : {audit_result_fairmodel_LR.lower_bound}. Is model fair: {audit_result_fairmodel_LR.is_model_fair}\")\n",
+    "print(f\"Loss ratio (fair model - EXPLORE metric) : {audit_result_fairmodel_explore.lower_bound}. Is model fair: {audit_result_fairmodel_explore.is_model_fair}\")\n",
+    "print(\"-\"*100)\n",
+    "print(\"\\t As signified by these numbers, the fair models are fairer than the standard model\")\n",
     "print(\"=\"*100)"
    ]
   },
@@ -626,11 +741,8 @@
   }
  ],
  "metadata": {
-  "interpreter": {
-   "hash": "1ff634e5a2199fb3fbd063cbcb535063e93d355be71aa4c5535f7c54643d696f"
-  },
   "kernelspec": {
-   "display_name": "Python 3.8.13 ('infairness_notebook')",
+   "display_name": "Python 3.8.13 ('infairness')",
    "language": "python",
    "name": "python3"
   },
@@ -644,7 +756,12 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.12"
+   "version": "3.8.13"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "a2fcd21fd76dae422ddd233e5f13f95d1b9f33f06ee3b038abc60116b464585a"
+   }
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Updates the adult income prediction experiments as follows:
- separates protected attributes from X_train and uses the remaining variables to train the model
- Adds EXPLORE fair metric along with LogReg
- Adds auditing with SenSR with both LogReg and EXPLORE metrics